### PR TITLE
テスト環境の secret_key_base の設定を修正

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,5 +51,5 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.secret_key_base = ENV['SECRET_KEY_BASE'] || Rails.application.credentials.secret_key_base
+  config.secret_key_base = Rails.application.credentials.secret_key_base
 end


### PR DESCRIPTION
## 概要
config/environments/test.rb において、ENV からのフォールバックを削除し、Rails.application.credentials.secret_key_base を直接使用するように修正

## セルフレビュー
- [x] Guard の実行結果に問題が無い
- [ ] `yard` コメントの記述漏れが無い
- [ ] `OpenAPI Specification` の変更漏れが無い

## 参考資料
- 実装などで参考にしたもののリンクを貼る

## その他
- 何かあれば
